### PR TITLE
fix: resolve 'indexOf' of undefined in some cases

### DIFF
--- a/lib/util/findNextPunctuators.js
+++ b/lib/util/findNextPunctuators.js
@@ -56,8 +56,8 @@ function gatherAssignmentsFromNodes(statements, source) {
 }
 
 function parseStatements(node, exprNode) {
-  var tokens = findParentTokens(exprNode, node),
-      index = tokens.indexOf(exprNode),
+  var tokens = findParentTokens(exprNode, node)||[];
+  var index = tokens.indexOf(exprNode),
       statements = isWrappedBySwitchCaseBlock(node)
         ? node.parent.parent.consequent
         : tokens.slice(0).splice(index, tokens.length - index);

--- a/test/lib/rules/var-spacing.rule.js
+++ b/test/lib/rules/var-spacing.rule.js
@@ -1453,6 +1453,20 @@ ruleTester.run('var-spacing', rule, {
       '}'
     ].join('\n'),
     options: [false]
+  }, {
+    code: [
+      'if (a)',
+      'b = c;',
+      'd = f;'
+    ].join('\n')
+  }, {
+    code: [
+      'if(true) a = 1;',
+      'const value2 = {};'
+    ].join('\n'),
+    parserOptions: {
+      ecmaVersion: 6
+    },
   }],
   invalid: [{
     code: [


### PR DESCRIPTION
### Overview

in some cases, findParentTokens return null instead of an empty array. This PR prevent this.

### Related/Resolved tickets

all tickets that are related to the PR should be placed here...
Fixes #30

### Breaking changes

no breaking changes
